### PR TITLE
Fix typo

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -58,37 +58,37 @@ Use **Errands** to configure the BOSH Errands used by a9s MongoDB for PCF. For m
 
 ### Post-Deploy Errands
 
- * **Run BOSH Configurator**: 
+ * **Run BOSH Configurator**:
 	This errand configures **a9s BOSH for PCF** so that it can provision MongoDB
-	service instances. When enabled, this errand uploads the required
-	stemcells in the BOSH release. Disabling this errand may speed up the
-	deployment of all tiles.
+  service instances. When enabled, this errand uploads the required releases in
+  the a9s BOSH Director. Disabling this errand may speed up the deployment of
+  all tiles.
 
 	<p class="note"><strong>Note</strong>: To ensure your configuration remains up-to-date, disable this errand only when necessary.</p>
 
- * **Run Template Uploader**: 
+ * **Run Template Uploader**:
 	This errand is required to configure generic components that are included in a9s MongoDB for PCF with MongoDB  configurations.
 	Disabling this errand may speed up the deployment of all tiles.
 
 	<p class="note"><strong>Note</strong>: To ensure your configuration remains up-to-date, disable this errand only when necessary.</p>
 
- * **Run Broker Registrar**: 
+ * **Run Broker Registrar**:
 	This errand registers the a9s MongoDB for PCF service broker
 	at the Elastic Runtime. This causes the service be available in the Elastic Runtime
 	marketplace.
 
- * **Run Smoke Tests**: 
+ * **Run Smoke Tests**:
  This errand runs a series of basic tests against your a9s MongoDB for PCF
  installation to ensure that it is configured properly. Those tests may
  take a certain amount of time, probably over 30 minutes.
 
 ### Pre-Delete Errands
 
- * **Delete all a9s MongoDB instances**: 
+ * **Delete all a9s MongoDB instances**:
 	This errand deletes all a9s MongoDB instances created by PCF end users  with `cf create-service` .
 	<p class="note warning"><strong>WARNING</strong>: This is a destructive task that cannot be undone. It irrecoverably deletes all VMs of the service instances. If a service instance is bound to an app or service keys exist, the errand fails.</p>
 
- * **Run Broker Deregistrar**: 
+ * **Run Broker Deregistrar**:
 	This will deregister the a9s MongoDB for PCF service broker in Elastic Runtime. This errand removes the a9s MongoDB service from the Elastic Runtime marketplace.
 
 ##<a id="configure-service-instance"></a> Configure Service Plans

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -99,7 +99,7 @@ Before you can delete a service instance, you must unbind it from all apps.
 
 ### List Available Services
 
-Run `cf service` to list your available services.
+Run `cf services` to list your available services.
 
 <pre class="terminal">
 $ cf services

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -102,7 +102,7 @@ Before you can delete a service instance, you must unbind it from all apps.
 Run `cf service` to list your available services.
 
 <pre class="terminal">
-$ cf service
+$ cf services
 
 Getting services in org test / space test as admin...
 OK


### PR DESCRIPTION
This commits fixes a typo where the command "cf services" is actually run even though the text stipulates "cf service".

It also changes the explanation in the BOSH errand paragraph, since the stemcells have been removed from the tiles – but the task still uploads the releases on which it depends.