### PR TITLE
Create release 1.1.0

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -7,7 +7,7 @@ This documentation describes the a9s MongoDB for Pivotal Cloud Foundry (PCF) til
 enables on-demand provisioning of VM-based, dedicated MongoDB servers and clusters. Developers can
 create instances of a MongoDB server or cluster using Apps Manager or the Cloud Foundry Command Line
 interface (cf CLI) and bind these instances to an application.
-Depending on your service plan, a service instance may be associated with a single, dedicated VM 
+Depending on your service plan, a service instance may be associated with a single, dedicated VM
 or a set of VMs consisting of multiple VMs containing a MongoDB replica set cluster.
 
 <%= image_tag("a9s-mongodb-tile.png") %>
@@ -73,11 +73,11 @@ The following table provides version and version-support information about a9s M
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.0.1</td>
+        <td>v1.1.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>April 20, 2017</td>
+        <td>June 1, 2017</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -105,18 +105,18 @@ For more information, see [Installing and Configuring a9s MongoDB for PCF](./ins
 
 ## <a id="feedback"></a>Feedback and Support
 
-a9s MongoDB for PCF is an automation toolset for open source MongoDB. 
-The entire anynines team can help your team  get started and be successful. 
+a9s MongoDB for PCF is an automation toolset for open source MongoDB.
+The entire anynines team can help your team  get started and be successful.
 Technical support, including a service level agreement, is available with a commercial license.
 
-If your company has specific MongoDB administration policies or configuration best practises, 
-the anynines team is happy to incorporate them, if applicable. 
+If your company has specific MongoDB administration policies or configuration best practises,
+the anynines team is happy to incorporate them, if applicable.
 Third-party MongoDB support organizations are also welcome to assist.
 
-Contributions are welcome and will be investigated by the anynines team. 
+Contributions are welcome and will be investigated by the anynines team.
 Please send any bugs, feature requests, or questions to svc.support@anynines.com.
 
 ## <a id='license'></a>License
 
-Contact our sales team to learn more about commercial licenses 
+Contact our sales team to learn more about commercial licenses
 and support at <a href="http://data-services.anynines.com/sales" target="_blank">data-services.anynines.com/sales</a>.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -3,19 +3,25 @@ title: a9s MongoDB for PCF Release Notes
 owner: Partners
 ---
 
-### v1.0.1
+## <a id="1-1-0"></a>v1.1.0
 
-**Release Date:** April 20, 2017
+**Release Date:** June 1, 2017
 
-* Added icon for Apps Manager.
+* Added a Backup Manager that allows the creation of manual and automatic backups and manual recoveries.
+* Added a Service Guard that creates security groups for your instance.
 
 Known issues in this release:
 
 * Failed backups with empty configuration — The Backup Manager schedules backups
 even when its settings are left empty and these backups are displayed as “failed” in the Backup Manager API.
 
+## <a id="1-0-1"></a>v1.0.1
 
-### v1.0.0
+**Release Date:** April 20, 2017
+
+* Added icon for Apps Manager.
+
+## <a id="1-0-0"></a>v1.0.0
 
 **Release Date:** March 14, 2017
 
@@ -24,26 +30,26 @@ Features included in this release:
 * Removed stemcell from tile to the a9s Bosh for PCF tile
 * Remove restriction to have three AZs configured in the a9s Bosh for PCF
 
-### v0.10.0
+## <a id="0-10-0"></a>v0.10.0
 
 **Release Date:** January 13, 2017
 
 * Service Instance Plan Upgrade
 * Logging and Monitoring
 
-### v0.9.2
+## <a id="0-9-2"></a>v0.9.2
 
 **Release Date:** November 18, 2016
 
 *  Added a smoke tests errand. See <a href="./installing.html#errands" target="_blank">the errands chapter</a> for more information.
 
-### v0.9.1
+## <a id="0-9-1"></a>v0.9.1
 
 **Release Date:** October 17, 2016
 
 * Fixed a bug related to service deletion.
 
-### v0.9.0
+## <a id="0-9-0"></a>v0.9.0
 
 **Release Date:** September 1, 2016
 


### PR DESCRIPTION
Hello,

we forgot to create a new version in the docs for the last feature we added (Service Guard, Backup Maanger). This is now things done.

This new version corresponds to the tile tarball that my colleague @wolfoo2931 sent you.

I also made links out of the release versions.

Cheers,
Lucas